### PR TITLE
Update README to include information about Photo Library and Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Full-featured blog post management:
 
 Manage your pictures on some.pics:
 
-- Upload new images
+- Upload new images from your Photo Library or drag and drop images from Finder
 - Delete pictures
 - Copy photo URL, Some Pics URL, or as Markdown (link or image)
 - Open in browser


### PR DESCRIPTION
Updated the documentation to include the fact that Triton can import photos from Photo Library, but also from Finder via drag-and-drop.

Fixes: #4.