### PR TITLE
Handle optional account name with "Anonymous" fallback

### DIFF
--- a/Packages/AccountUpdate/Sources/AccountUpdateNetworkService/AccountUpdateNetworkService.swift
+++ b/Packages/AccountUpdate/Sources/AccountUpdateNetworkService/AccountUpdateNetworkService.swift
@@ -76,11 +76,19 @@ private extension AccountResponse {
 
     /// Initializes the `AccountResponse` model from the network response
     /// model, so that the client doesn't depend on network models.
+    ///
+    /// If the name from the API response is `nil` or empty, it defaults to "Anonymous"
+    /// to ensure all layers of the application work with a non-optional name value.
+    ///
     /// - Parameter response: The network model to be mapped.
     init(
         response: AccountInformationResponse.Response
     ) {
-        name = response.name
+        if let responseName = response.name, !responseName.isEmpty {
+            name = responseName
+        } else {
+            name = "Anonymous"
+        }
         email = response.email
         unixEpochTime = response.created.unixEpochTime
     }

--- a/Packages/OMGAPI/Sources/OMGAPI/Responses/AccountInformationResponse.swift
+++ b/Packages/OMGAPI/Sources/OMGAPI/Responses/AccountInformationResponse.swift
@@ -16,7 +16,7 @@ public extension AccountInformationResponse {
 
         public let message: String
         public let email: String
-        public let name: String
+        public let name: String?
         public let created: Created
     }
 }


### PR DESCRIPTION
Make account name optional in API response and map nil/empty values to "Anonymous" at the network boundary. This ensures users who haven't set their name can remain anonymous while keeping the name non-optional in domain and UI layers.

- Make AccountInformationResponse.Response.name optional (String?)
- Add mapping logic in AccountUpdateNetworkService to default nil/empty names to "Anonymous"
- Preserve non-optional String type in AccountResponse and Account models
- No changes required in UI or persistence layers

Fixes: #3.