### PR TITLE
Fix 401 error when publishing a new weblog entry

### DIFF
--- a/Packages/Weblog/Sources/Weblog/Scenes/EditWeblogEntryScene.swift
+++ b/Packages/Weblog/Sources/Weblog/Scenes/EditWeblogEntryScene.swift
@@ -24,8 +24,8 @@ struct EditWeblogEntryScene: Scene {
             for: EditWeblogEntry.self
         ) { $entry in
             makeEditorView(
-                body: entry?.body ?? "# Title of your post\n\nThis is the body of your post...",
-                date: entry?.date ?? Date(),
+                body: entry?.body ?? "",
+                date: entry?.date ?? .init(),
                 entryID: entry?.entryID,
                 address: entry?.address ?? ""
             )

--- a/Packages/Weblog/Sources/Weblog/Views/App/WeblogApp.swift
+++ b/Packages/Weblog/Sources/Weblog/Views/App/WeblogApp.swift
@@ -78,9 +78,19 @@ struct WeblogApp: View {
     }
 
     @ViewBuilder
-    private func makeAddEntryToolbarItem() -> some View {
+    private func makeAddEntryToolbarItem(
+        address: SelectedAddress
+    ) -> some View {
         Button {
-            openWindow(id: EditWeblogEntryWindow.id)
+            openWindow(
+                id: EditWeblogEntryWindow.id,
+                value: EditWeblogEntry(
+                    address: address,
+                    body: "# Title of your post\n\nThis is the body of your post...",
+                    date: .init(),
+                    entryID: nil
+                )
+            )
         } label: {
             Image(systemName: "plus")
         }
@@ -108,7 +118,7 @@ struct WeblogApp: View {
                 helpText: "Refresh weblog entries",
                 isDisabled: viewModel.isLoading
             )
-            makeAddEntryToolbarItem()
+            makeAddEntryToolbarItem(address: address)
         }
     }
 }


### PR DESCRIPTION
The add entry button in the toolbar wasn’t passing the selected address to the lower layers. As result, Triton was making a network request to create a new post without the address. In such cases, the API returns an error, 401.

This commit ensures the address is getting passed down to the lower layers before making the network request.