### PR TITLE
Drive signing & bundle prefix from an xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Packages/*/Package.resolved
 
 # Environment
 .env
+
+# Per-machine signing override (see Config/Triton.local.xcconfig.example)
+Config/Triton.local.xcconfig

--- a/Config/Triton.local.xcconfig.example
+++ b/Config/Triton.local.xcconfig.example
@@ -1,0 +1,14 @@
+// Per-machine signing override — TEMPLATE.
+//
+// Copy this file to `Triton.local.xcconfig` (same directory) and fill in your own values to build
+// under a different developer account / bundle prefix. `Triton.local.xcconfig` is gitignored;
+// `Triton.xcconfig` includes it optionally via `#include? "Triton.local.xcconfig"`, so it overrides
+// the committed defaults when present and is ignored when absent.
+//
+//     cp Triton.local.xcconfig.example Triton.local.xcconfig
+//
+// `TRITON_BUNDLE_PREFIX` is your reverse-DNS organisation prefix (everything before `.OMG`);
+// `DEVELOPMENT_TEAM` is your 10-character Apple Developer team identifier.
+
+TRITON_BUNDLE_PREFIX =
+DEVELOPMENT_TEAM =

--- a/Config/Triton.xcconfig
+++ b/Config/Triton.xcconfig
@@ -1,0 +1,18 @@
+// Per-machine signing & identity configuration.
+//
+// This committed file holds the defaults used on the maintainer's primary machine. To build under a
+// different developer account / bundle prefix (e.g. a personal Apple ID on another machine), DO NOT
+// edit this file — create `Config/Triton.local.xcconfig` (gitignored) overriding the two settings
+// below (see Config/Triton.local.xcconfig.example for a template), e.g.:
+//
+//     TRITON_BUNDLE_PREFIX = com.example
+//     DEVELOPMENT_TEAM = ABCDE12345
+//
+// `TRITON_BUNDLE_PREFIX` is the reverse-DNS organisation prefix (everything before `.OMG`); it drives
+// the app's bundle identifier. `Triton.local.xcconfig` is included optionally at the end, so it wins
+// when present and is simply absent on the maintainer's machine.
+
+TRITON_BUNDLE_PREFIX = com.otaviocc
+DEVELOPMENT_TEAM = S9X9XY5GF8
+
+#include? "Triton.local.xcconfig"

--- a/Documentation/ADR/ADR-018-per-machine-signing-via-xcconfig.md
+++ b/Documentation/ADR/ADR-018-per-machine-signing-via-xcconfig.md
@@ -1,0 +1,67 @@
+# ADR-018: Per-Machine Signing via xcconfig
+
+**Status:** Accepted
+
+**Date:** 2026-06-27
+
+**Context:**
+
+The application is built on more than one machine, each signed under a different Apple developer
+account — the maintainer's primary account and a personal Apple ID. Two settings differ between those
+accounts:
+
+- `DEVELOPMENT_TEAM` — the Apple Developer team identifier used for signing.
+- The bundle-identifier prefix — an explicit App ID registered to one account cannot be reused by
+  another, so the second account needs its own reverse-DNS prefix (e.g. `cc.otavio.OMG` instead of
+  `com.otaviocc.OMG`).
+
+Both values were hardcoded in the committed `OMG.xcodeproj/project.pbxproj` (`DEVELOPMENT_TEAM` and
+`PRODUCT_BUNDLE_IDENTIFIER`). Switching machines meant editing a tracked file, which is noisy in git
+and easy to commit by accident.
+
+Unlike the sibling Stash project, the application has no Share Extension, no App Group, no Keychain
+access group, and no runtime code that reads the bundle identifier. The OAuth redirect uses a fixed
+custom scheme (`omglol://oauth/callback`) that is registered with omg.lol and is independent of the
+bundle prefix. The change is therefore confined to build settings — there are no entitlements,
+`Info.plist` identifiers, or Swift constants that must be kept in lockstep.
+
+**Decision:**
+
+Introduce `Config/Triton.xcconfig` as the single source for `DEVELOPMENT_TEAM` and a new
+`TRITON_BUNDLE_PREFIX` build setting, and wire it as the project-level base configuration.
+
+- The committed `Triton.xcconfig` holds the maintainer's defaults
+  (`TRITON_BUNDLE_PREFIX = com.otaviocc`, `DEVELOPMENT_TEAM = S9X9XY5GF8`).
+- `PRODUCT_BUNDLE_IDENTIFIER` in both target build configurations references
+  `$(TRITON_BUNDLE_PREFIX).OMG`. `DEVELOPMENT_TEAM` is removed from the `pbxproj` entirely (including
+  the empty target-level overrides) and now comes only from the xcconfig.
+- `Triton.xcconfig` ends with `#include? "Triton.local.xcconfig"`. The `?` makes the include optional,
+  so a second machine drops a gitignored `Config/Triton.local.xcconfig` overriding either setting and
+  it wins, while the maintainer's primary machine builds with no local file.
+- `Config/Triton.local.xcconfig.example` is committed as a template; `Config/Triton.local.xcconfig`
+  is gitignored.
+
+**Consequences:**
+
+- _Positive:_ Switching developer accounts no longer touches tracked files. Team and prefix live in
+  one place; the bundle identifier derives from the prefix so the two can't drift.
+- _Positive:_ The committed defaults keep CI and the primary machine building with zero local setup.
+- _Neutral:_ Building under a second account is a one-time `cp Config/Triton.local.xcconfig.example
+  Config/Triton.local.xcconfig` followed by editing the two values.
+- _Negative:_ The base-configuration wiring lives in `pbxproj`, so a future "reset project settings"
+  in Xcode could drop the `baseConfigurationReference`; verify resolved values with
+  `xcodebuild -scheme OMG -showBuildSettings` if signing behaves unexpectedly.
+
+**Related Decisions:**
+
+- [ADR-017: Direct Distribution Outside App Store](ADR-017-direct-distribution-outside-app-store.md) —
+  signing and notarization context this configuration feeds into.
+
+**Notes:**
+
+Verify a machine's resolved values with:
+
+```bash
+xcodebuild -scheme OMG -showBuildSettings \
+  | grep -E 'TRITON_BUNDLE_PREFIX|DEVELOPMENT_TEAM|PRODUCT_BUNDLE_IDENTIFIER'
+```

--- a/Documentation/ADR/README.md
+++ b/Documentation/ADR/README.md
@@ -81,6 +81,11 @@ Use of Mother Object pattern for creating reusable test fixtures that support Sw
 ### [ADR-017: Direct Distribution Outside App Store](ADR-017-direct-distribution-outside-app-store.md)
 Decision to distribute the application directly through downloadable installers outside the Mac App Store, prioritizing development velocity and cost efficiency while maintaining security through code signing and notarization.
 
+## Build Configuration
+
+### [ADR-018: Per-Machine Signing via xcconfig](ADR-018-per-machine-signing-via-xcconfig.md)
+Decision to drive `DEVELOPMENT_TEAM` and the bundle-identifier prefix from `Config/Triton.xcconfig` with an optional gitignored local override, so the app can be built under different developer accounts without editing tracked files.
+
 ## Contributing
 
 When making significant architectural decisions:

--- a/OMG.xcodeproj/project.pbxproj
+++ b/OMG.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		EAD89BCB2E6B2BF900C9041F /* Weblog */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Weblog; sourceTree = "<group>"; };
 		EADEE5FD2E786D3900204760 /* Pics */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Pics; sourceTree = "<group>"; };
 		EAE1723C29F5C08000AEC787 /* Pastebin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Pastebin; sourceTree = "<group>"; };
+		B1A5C0FFEE0000000000C0DE /* Triton.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Triton.xcconfig"; path = "Config/Triton.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -99,10 +100,19 @@
 			isa = PBXGroup;
 			children = (
 				EAA086842E8EA353005D4406 /* OMG */,
+				B1A5C0FFEE0000000000C0DF /* Config */,
 				EAC944E6295E5873004EE34F /* Packages */,
 				EAC944D5295E56E9004EE34F /* Products */,
 				EAD763042960953600E18E02 /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		B1A5C0FFEE0000000000C0DF /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				B1A5C0FFEE0000000000C0DE /* Triton.xcconfig */,
+			);
+			name = Config;
 			sourceTree = "<group>";
 		};
 		EAC944D5295E56E9004EE34F /* Products */ = {
@@ -295,6 +305,7 @@
 /* Begin XCBuildConfiguration section */
 		EAC944E1295E56EA004EE34F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B1A5C0FFEE0000000000C0DE /* Triton.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -329,7 +340,6 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = S9X9XY5GF8;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -360,6 +370,7 @@
 		};
 		EAC944E2295E56EA004EE34F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B1A5C0FFEE0000000000C0DE /* Triton.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -394,7 +405,6 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = S9X9XY5GF8;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -428,7 +438,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"OMG/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -453,7 +462,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.6;
-				PRODUCT_BUNDLE_IDENTIFIER = com.otaviocc.OMG;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TRITON_BUNDLE_PREFIX).OMG";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -478,7 +487,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"OMG/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -503,7 +511,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.6;
-				PRODUCT_BUNDLE_IDENTIFIER = com.otaviocc.OMG;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TRITON_BUNDLE_PREFIX).OMG";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/Packages/FoundationExtensions/Tests/FoundationExtensionsTests/ArrayContainsTests.swift
+++ b/Packages/FoundationExtensions/Tests/FoundationExtensionsTests/ArrayContainsTests.swift
@@ -172,8 +172,7 @@ struct ArrayContainsTests {
     }
 
     @Test
-    func `It should return false when array contains empty string and partial is empty (empty string matches nothing)`(
-    ) {
+    func `It should return false when array contains empty string and partial is empty (empty string matches nothing)`() {
         // Given
         let array = ["apple", "", "banana"]
         let partial = ""
@@ -189,8 +188,7 @@ struct ArrayContainsTests {
     }
 
     @Test
-    func `It should return true when searching for non-empty partial in array with empty string (should match 'apple')`(
-    ) {
+    func `It should return true when searching for non-empty partial in array with empty string (should match 'apple')`() {
         // Given
         let array = ["apple", "", "banana"]
         let partial = "app"


### PR DESCRIPTION
## Summary

The app is built on more than one machine, each signed under a different Apple developer account — but `DEVELOPMENT_TEAM` and the bundle prefix were hardcoded in the committed project, so switching machines meant editing a tracked file.

This introduces `Config/Triton.xcconfig` as the single source for both `DEVELOPMENT_TEAM` and a new `TRITON_BUNDLE_PREFIX`, wired as the project-level base configuration.

- The committed `Triton.xcconfig` holds the maintainer's defaults.
- It ends with `#include? "Triton.local.xcconfig"` — a second machine drops a gitignored override (templated by `Triton.local.xcconfig.example`, which ships with empty placeholders) without touching tracked files.
- `PRODUCT_BUNDLE_IDENTIFIER` now references `$(TRITON_BUNDLE_PREFIX).OMG`; `DEVELOPMENT_TEAM` is removed from the `pbxproj` entirely (including the empty target-level overrides).

No App Group, entitlements, or runtime bundle-ID reads exist in this project, so the change is confined to build settings — the OAuth redirect scheme is untouched.

## To build under a different account

```bash
cp Config/Triton.local.xcconfig.example Config/Triton.local.xcconfig
# edit TRITON_BUNDLE_PREFIX and DEVELOPMENT_TEAM
```

## Test plan

- `xcodebuild -scheme OMG -showBuildSettings` resolves to the committed defaults; with a local override present, team and bundle ID flip and revert when removed.
- `xcodebuild -scheme OMG -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED**.

Documented in ADR-018.